### PR TITLE
Combine total messages

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -21,10 +21,21 @@ pdf = matplotlib.backends.backend_pdf.PdfPages("output.pdf")
 #Gather totalMessages and AverageResponseTime for all users and trim names if they're too long 
 for user in userDict:
     currentUserName = userDict[user].getFullName()
-    if len(currentUserName) >= 26:
+    currentUserId = userDict[user].getPeerID()
+    currentMessages = userDict[user].getNumMessages()
+    if len(currentUserName) >= 26: #Ensure that long names will still fit on the graph
         currentUserName = currentUserName[:-5] + "..."
+
+    #Code used to check if the same user (determined by name) occurs twice in the data, due to phone number change 
+    for secondUser in userDict: #Loop through the users again to check if any of them have the same print name
+        secondUserName = userDict[secondUser].getFullName()
+        secondUserId = userDict[secondUser].getPeerID()
+        secondUserMessages = userDict[secondUser].getNumMessages()
+        if currentUserName == secondUserName and currentUserId != secondUserId: #If they have the same print name but different IDs combine total messages
+            currentMessages+= userDict[secondUser].getNumMessages()
+
     userList.append(currentUserName)
-    totalMessagesPerUser.append(userDict[user].getNumMessages())    
+    totalMessagesPerUser.append(currentMessages)    
     responseTimePerUser.append(userDict[user].getAverageResponseTime())
 
 def graphData():

--- a/user.py
+++ b/user.py
@@ -201,6 +201,12 @@ class UserData(object):
         Return dictionary with words specified by user to be checked, each word has its own ActivityInfo object 
         """
         return self.wordDict
+    
+    def getPeerID(self):
+        """
+        Return current user's unique id
+        """
+        return self.id
 
     def printInfo(self):
         """


### PR DESCRIPTION
If two seemingly unique users have the same display name, combine their total messages sent. This is useful if the same person ends up making two different accounts and wants to see the total sum of their activity